### PR TITLE
refactor: 토큰 첫 1회 발급 후, 토큰에 문제 발생 시 재요청 하도록 로직 변경 

### DIFF
--- a/src/main/java/kimsy/groceryapi/exception/presentation/BusinessExceptionController.java
+++ b/src/main/java/kimsy/groceryapi/exception/presentation/BusinessExceptionController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
 public class BusinessExceptionController {
-
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public String illegalArgsHandler(RuntimeException e, Model model) {

--- a/src/main/java/kimsy/groceryapi/exception/presentation/WebClientExceptionController.java
+++ b/src/main/java/kimsy/groceryapi/exception/presentation/WebClientExceptionController.java
@@ -10,7 +10,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 @ControllerAdvice
 public class WebClientExceptionController {
-
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(WebClientResponseException.NotFound.class)
     public String notFountHandler(Model model) {

--- a/src/main/java/kimsy/groceryapi/product/domain/AccessToken.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/AccessToken.java
@@ -4,10 +4,10 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-class AccessToken {
+public class AccessToken {
     private String accessToken;
 
-    AccessToken(final String accessToken) {
+    public AccessToken(final String accessToken) {
         this.accessToken = accessToken;
     }
 

--- a/src/main/java/kimsy/groceryapi/product/domain/AccessToken.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/AccessToken.java
@@ -1,10 +1,11 @@
 package kimsy.groceryapi.product.domain;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 class AccessToken {
     private String accessToken;
-
-    AccessToken() {
-    }
 
     AccessToken(final String accessToken) {
         this.accessToken = accessToken;

--- a/src/main/java/kimsy/groceryapi/product/domain/FruitWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/FruitWebClient.java
@@ -1,33 +1,53 @@
 package kimsy.groceryapi.product.domain;
 
 import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+@Slf4j
 @Component
 public class FruitWebClient {
     private final WebClient fruitWebClient;
+    private AccessToken accessToken;
 
+    @Autowired
     public FruitWebClient(@Value("${api.url.fruit}") String fruitUrl) {
         fruitWebClient = WebClient.builder().baseUrl(fruitUrl).build();
+        accessToken = getToken();
+    }
+
+    public FruitWebClient(final String fruitUrl, final AccessToken accessToken) {
+        this.fruitWebClient = WebClient.builder().baseUrl(fruitUrl).build();
+        this.accessToken = accessToken;
     }
 
     public Products getProducts() {
-        final AccessToken accessToken = getToken();
-        final String[] result = fruitWebClient.get()
+        String[] result;
+        try {
+            result = requestForProducts();
+        } catch (WebClientResponseException e) {
+            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
+
+            accessToken = getToken();
+            result = requestForProducts();
+        }
+
+        validateNull(result);
+        return new Products(Arrays.stream(result).toList());
+    }
+
+    private String[] requestForProducts() {
+        return fruitWebClient.get()
                 .uri(ProductType.FRUIT.productUri())
                 .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
                 .retrieve()
                 .bodyToMono(String[].class)
                 .block();
-
-        if (result == null) {
-            throw new IllegalStateException("정보를 가져오는 데 실패했습니다.");
-        }
-
-        return new Products(Arrays.stream(result).toList());
     }
 
     private AccessToken getToken() {
@@ -39,7 +59,21 @@ public class FruitWebClient {
     }
 
     public Product getPrice(final String productName) {
-        final AccessToken accessToken = getToken();
+        Product result;
+        try {
+            result = requestForProduct(productName);
+        } catch (WebClientResponseException e) {
+            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
+
+            accessToken = getToken();
+            result = requestForProduct(productName);
+        }
+
+        validateNull(result);
+        return result;
+    }
+
+    private Product requestForProduct(final String productName) {
         return fruitWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(ProductType.FRUIT.productUri())
@@ -49,5 +83,11 @@ public class FruitWebClient {
                 .retrieve()
                 .bodyToMono(Product.class)
                 .block();
+    }
+
+    private <T> void validateNull(T t) {
+        if (t == null) {
+            throw new IllegalStateException("정보를 가져오는 데 실패했습니다.");
+        }
     }
 }

--- a/src/main/java/kimsy/groceryapi/product/domain/Product.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/Product.java
@@ -1,5 +1,9 @@
 package kimsy.groceryapi.product.domain;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Product {
     private String name;
     private Integer price;

--- a/src/main/java/kimsy/groceryapi/product/domain/ProductWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/ProductWebClient.java
@@ -34,7 +34,7 @@ public class ProductWebClient {
         throw new IllegalArgumentException("서비스를 지원하지 않는 품목입니다.");
     }
 
-    private static void validate(final String productName) {
+    private void validate(final String productName) {
         if (!StringUtils.hasText(productName)) {
             throw new IllegalArgumentException("품목명을 입력해 주세요.");
         }

--- a/src/main/java/kimsy/groceryapi/product/domain/ProductWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/ProductWebClient.java
@@ -1,18 +1,14 @@
 package kimsy.groceryapi.product.domain;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@RequiredArgsConstructor
 @Component
 public class ProductWebClient {
     private final FruitWebClient fruitClient;
     private final VegetableWebClient vegetableWebClient;
-
-    public ProductWebClient(final FruitWebClient fruitClient,
-            final VegetableWebClient vegetableWebClient) {
-        this.fruitClient = fruitClient;
-        this.vegetableWebClient = vegetableWebClient;
-    }
 
     public Products getProducts(final String productType) {
         if (ProductType.isFruit(productType)) {

--- a/src/main/java/kimsy/groceryapi/product/presentation/ProductController.java
+++ b/src/main/java/kimsy/groceryapi/product/presentation/ProductController.java
@@ -6,13 +6,11 @@ import kimsy.groceryapi.product.application.dto.ProductsResponse;
 import kimsy.groceryapi.product.presentation.dto.ProductPriceRequest;
 import kimsy.groceryapi.product.presentation.dto.ProductsSearchRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@Slf4j
 @RequestMapping("/product")
 @RequiredArgsConstructor
 @Controller

--- a/src/test/java/kimsy/groceryapi/product/application/ProductServiceTest.java
+++ b/src/test/java/kimsy/groceryapi/product/application/ProductServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import kimsy.groceryapi.product.application.dto.ProductPriceResponse;
 import kimsy.groceryapi.product.application.dto.ProductsResponse;
+import kimsy.groceryapi.product.domain.AccessToken;
 import kimsy.groceryapi.product.domain.FruitWebClient;
 import kimsy.groceryapi.product.domain.ProductWebClient;
 import kimsy.groceryapi.product.domain.VegetableWebClient;
@@ -47,17 +48,14 @@ class ProductServiceTest {
     private ProductService productService;
 
     @BeforeEach
-    void setUp() throws JsonProcessingException {
+    void setUp() {
         final String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
 
-        ProductWebClient productWebClient = new ProductWebClient(new FruitWebClient(baseUrl),
-                new VegetableWebClient(baseUrl));
+        ProductWebClient productWebClient = new ProductWebClient(
+                new FruitWebClient(baseUrl, new AccessToken("token")),
+                new VegetableWebClient(baseUrl, new AccessToken("token")));
 
         productService = new ProductService(productWebClient);
-
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(objectMapper.writeValueAsString(TOKEN))
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
     }
 
     @DisplayName("품목에 대한 전체 상품 목록이 들어있는 ProductsResponse를 반환한다.")

--- a/src/test/java/kimsy/groceryapi/product/domain/ProductWebClientTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/ProductWebClientTest.java
@@ -21,8 +21,6 @@ import org.springframework.http.MediaType;
 
 class ProductWebClientTest {
     private static MockWebServer mockWebServer;
-    private static final String TOKEN_FOR_FRUIT = "{ \"accessToken\" : \"token\" }";
-    private static final String TOKEN_FOR_VEGETABLE = "Authorization=token";
 
     @BeforeAll
     static void beforeAll() throws IOException {
@@ -42,10 +40,9 @@ class ProductWebClientTest {
     void setUp() {
         final String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
 
-        FruitWebClient fruitWebClient = new FruitWebClient(baseUrl);
-        VegetableWebClient vegetableWebClient = new VegetableWebClient(baseUrl);
-
-        productWebClient = new ProductWebClient(fruitWebClient, vegetableWebClient);
+        productWebClient = new ProductWebClient(
+                new FruitWebClient(baseUrl, new AccessToken("token")),
+                new VegetableWebClient(baseUrl, new AccessToken("token")));
     }
 
 
@@ -56,10 +53,6 @@ class ProductWebClientTest {
         @DisplayName("ProductType으로 fruit이 전달된 경우 과일 목록을 반환한다.")
         @Test
         void fruitToProductNames() throws JsonProcessingException {
-            mockWebServer.enqueue(new MockResponse()
-                    .setBody(objectMapper.writeValueAsString(TOKEN_FOR_FRUIT))
-                    .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
-
             final String[] expect = {"배", "토마토", "사과", "바나나"};
             mockWebServer.enqueue(new MockResponse()
                     .setBody(objectMapper.writeValueAsString(expect))
@@ -76,10 +69,6 @@ class ProductWebClientTest {
         @DisplayName("ProductType으로 vegetable이 전달된 경우 채소 목록을 반환한다.")
         @Test
         void vegetableToProductNames() throws JsonProcessingException {
-            mockWebServer.enqueue(new MockResponse()
-                    .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                    .addHeader(HttpHeaders.SET_COOKIE, TOKEN_FOR_VEGETABLE));
-
             final String[] expect = {"치커리", "토마토", "깻잎", "상추"};
             mockWebServer.enqueue(new MockResponse()
                     .setBody(objectMapper.writeValueAsString(expect))
@@ -109,10 +98,6 @@ class ProductWebClientTest {
         @DisplayName("productType=fruit, productName=배 가 전달된 경우 배의 가격을 반환한다.")
         @Test
         void searchFruitPair() throws JsonProcessingException {
-            mockWebServer.enqueue(new MockResponse()
-                    .setBody(objectMapper.writeValueAsString(TOKEN_FOR_FRUIT))
-                    .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
-
             final String productName = "배";
             final int productPrice = 3000;
             mockWebServer.enqueue(new MockResponse()
@@ -130,10 +115,6 @@ class ProductWebClientTest {
         @DisplayName("productType=vegetable, productName=깻잎 이 전달된 경우 깻잎의 가격을 반환한다.")
         @Test
         void searchVegetableSesame() throws JsonProcessingException {
-            mockWebServer.enqueue(new MockResponse()
-                    .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                    .addHeader(HttpHeaders.SET_COOKIE, TOKEN_FOR_VEGETABLE));
-
             final String productName = "깻잎";
             final int productPrice = 1500;
             mockWebServer.enqueue(new MockResponse()


### PR DESCRIPTION
## 요약
토큰 첫 1회 발급 후, 저장하여 재사용 하다가 토큰에 문제 발생 시 재요청 하도록 로직 변경 

## 작업 내용 
- `FruitWebClient` 및 `VegetableWebClient` 빈 등록 시 토큰 발급 후 저장 (필드에 저장)
- API 서버는 토큰이 없거나 이상한 토큰을 보낼 시  400 BadRequest를 리턴 -> 해당 예외를 잡아 토큰을 재발급 처리하도록 로직 구성 
- 로직 변경으로 인한 mockServer(`okHttp`) 테스트 코드 수정 


