### PR TITLE
refactor: 중복된 로직을 해결하기 위한 템플릿 메소드 패턴 적용

### DIFF
--- a/src/main/java/kimsy/groceryapi/product/application/ProductService.java
+++ b/src/main/java/kimsy/groceryapi/product/application/ProductService.java
@@ -3,7 +3,7 @@ package kimsy.groceryapi.product.application;
 import kimsy.groceryapi.product.application.dto.ProductPriceResponse;
 import kimsy.groceryapi.product.application.dto.ProductsResponse;
 import kimsy.groceryapi.product.domain.Product;
-import kimsy.groceryapi.product.domain.ProductWebClient;
+import kimsy.groceryapi.product.domain.ProductWebClientAdapter;
 import kimsy.groceryapi.product.domain.Products;
 import kimsy.groceryapi.product.presentation.dto.ProductPriceRequest;
 import kimsy.groceryapi.product.presentation.dto.ProductsSearchRequest;
@@ -13,15 +13,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class ProductService {
-    private final ProductWebClient productWebClient;
+    private final ProductWebClientAdapter productWebClientAdapter;
 
     public ProductsResponse getProducts(final ProductsSearchRequest productsSearchRequest) {
-        final Products products = productWebClient.getProducts(productsSearchRequest.productType());
+        final Products products = productWebClientAdapter.getProducts(productsSearchRequest.productType());
         return new ProductsResponse(products);
     }
 
     public ProductPriceResponse getProduct(final ProductPriceRequest productPriceRequest) {
-        final Product product = productWebClient.getProduct(productPriceRequest.productType(),
+        final Product product = productWebClientAdapter.getProduct(productPriceRequest.productType(),
                 productPriceRequest.productName());
         return new ProductPriceResponse(product);
     }

--- a/src/main/java/kimsy/groceryapi/product/domain/AccessToken.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/AccessToken.java
@@ -11,7 +11,7 @@ public class AccessToken {
         this.accessToken = accessToken;
     }
 
-    String accessToken() {
+    public String accessToken() {
         return accessToken;
     }
 

--- a/src/main/java/kimsy/groceryapi/product/domain/FruitWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/FruitWebClient.java
@@ -1,48 +1,24 @@
 package kimsy.groceryapi.product.domain;
 
-import java.util.Arrays;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-@Slf4j
 @Component
-public class FruitWebClient {
-    private final WebClient fruitWebClient;
-    private AccessToken accessToken;
-
+public class FruitWebClient extends GroceryWebClient {
     @Autowired
     public FruitWebClient(@Value("${api.url.fruit}") String fruitUrl) {
-        fruitWebClient = WebClient.builder().baseUrl(fruitUrl).build();
-        accessToken = getToken();
+        super(fruitUrl);
     }
 
     public FruitWebClient(final String fruitUrl, final AccessToken accessToken) {
-        this.fruitWebClient = WebClient.builder().baseUrl(fruitUrl).build();
-        this.accessToken = accessToken;
+        super(fruitUrl, accessToken);
     }
 
-    public Products getProducts() {
-        String[] result;
-        try {
-            result = requestForProducts();
-        } catch (WebClientResponseException e) {
-            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
-
-            accessToken = getToken();
-            result = requestForProducts();
-        }
-
-        validateNull(result);
-        return new Products(Arrays.stream(result).toList());
-    }
-
-    private String[] requestForProducts() {
-        return fruitWebClient.get()
+    @Override
+    String[] requestForProducts() {
+        return webClient.get()
                 .uri(ProductType.FRUIT.productUri())
                 .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
                 .retrieve()
@@ -50,31 +26,18 @@ public class FruitWebClient {
                 .block();
     }
 
-    private AccessToken getToken() {
-        return fruitWebClient.get()
+    @Override
+    AccessToken getToken() {
+        return webClient.get()
                 .uri(ProductType.FRUIT.tokenUri())
                 .retrieve()
                 .bodyToMono(AccessToken.class)
                 .block();
     }
 
-    public Product getPrice(final String productName) {
-        Product result;
-        try {
-            result = requestForProduct(productName);
-        } catch (WebClientResponseException e) {
-            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
-
-            accessToken = getToken();
-            result = requestForProduct(productName);
-        }
-
-        validateNull(result);
-        return result;
-    }
-
-    private Product requestForProduct(final String productName) {
-        return fruitWebClient.get()
+    @Override
+    Product requestForProduct(final String productName) {
+        return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(ProductType.FRUIT.productUri())
                         .queryParam("name", productName)
@@ -83,11 +46,5 @@ public class FruitWebClient {
                 .retrieve()
                 .bodyToMono(Product.class)
                 .block();
-    }
-
-    private <T> void validateNull(T t) {
-        if (t == null) {
-            throw new IllegalStateException("정보를 가져오는 데 실패했습니다.");
-        }
     }
 }

--- a/src/main/java/kimsy/groceryapi/product/domain/GroceryWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/GroceryWebClient.java
@@ -1,0 +1,64 @@
+package kimsy.groceryapi.product.domain;
+
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+public abstract class GroceryWebClient {
+    protected final WebClient webClient;
+    protected AccessToken accessToken;
+
+    public GroceryWebClient(final String url) {
+        this.webClient = WebClient.builder().baseUrl(url).build();
+        this.accessToken = getToken();
+    }
+
+    public GroceryWebClient(final String url, final AccessToken accessToken) {
+        this.webClient = WebClient.builder().baseUrl(url).build();
+        this.accessToken = accessToken;
+    }
+
+    abstract AccessToken getToken();
+
+    public Products getProducts() {
+        String[] result;
+        try {
+            result = requestForProducts();
+        } catch (WebClientResponseException e) {
+            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
+
+            accessToken = getToken();
+            result = requestForProducts();
+        }
+
+        validateNull(result);
+        return new Products(Arrays.stream(result).toList());
+    }
+
+    abstract String[] requestForProducts();
+
+    private <T> void validateNull(T t) {
+        if (t == null) {
+            throw new IllegalStateException("정보를 가져오는 데 실패했습니다.");
+        }
+    }
+
+    public Product getPrice(final String productName) {
+        Product result;
+        try {
+            result = requestForProduct(productName);
+        } catch (WebClientResponseException e) {
+            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
+
+            accessToken = getToken();
+            result = requestForProduct(productName);
+        }
+
+        validateNull(result);
+        return result;
+    }
+
+    abstract Product requestForProduct(String productName);
+}

--- a/src/main/java/kimsy/groceryapi/product/domain/ProductWebClientAdapter.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/ProductWebClientAdapter.java
@@ -6,7 +6,7 @@ import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 @Component
-public class ProductWebClient {
+public class ProductWebClientAdapter {
     private final FruitWebClient fruitClient;
     private final VegetableWebClient vegetableWebClient;
 

--- a/src/main/java/kimsy/groceryapi/product/domain/VegetableWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/VegetableWebClient.java
@@ -1,50 +1,26 @@
 package kimsy.groceryapi.product.domain;
 
-import java.util.Arrays;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
-@Slf4j
 @Component
-public class VegetableWebClient {
-    private final WebClient vegetableWebClient;
-    private AccessToken accessToken;
-
+public class VegetableWebClient extends GroceryWebClient {
     @Autowired
     public VegetableWebClient(@Value("${api.url.vegetable}") String vegetableUrl) {
-        vegetableWebClient = WebClient.builder().baseUrl(vegetableUrl).build();
-        accessToken = getToken();
+        super(vegetableUrl);
     }
 
     public VegetableWebClient(final String vegetableUrl, final AccessToken accessToken) {
-        vegetableWebClient = WebClient.builder().baseUrl(vegetableUrl).build();
-        this.accessToken = accessToken;
+        super(vegetableUrl, accessToken);
     }
 
-    public Products getProducts() {
-        String[] result;
-        try {
-            result = requestForProducts();
-        } catch (WebClientResponseException e) {
-            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
-
-            accessToken = getToken();
-            result = requestForProducts();
-        }
-
-        validateNull(result);
-        return new Products(Arrays.stream(result).toList());
-    }
-
-    private String[] requestForProducts() {
-        return vegetableWebClient.get()
+    @Override
+    String[] requestForProducts() {
+        return webClient.get()
                 .uri(ProductType.VEGETABLE.productUri())
                 .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
                 .retrieve()
@@ -52,8 +28,9 @@ public class VegetableWebClient {
                 .block();
     }
 
-    private AccessToken getToken() {
-        return vegetableWebClient.get()
+    @Override
+    AccessToken getToken() {
+        return webClient.get()
                 .uri(ProductType.VEGETABLE.tokenUri())
                 .exchangeToMono(response -> {
                     final ResponseCookie responseCookie = response.cookies()
@@ -67,23 +44,9 @@ public class VegetableWebClient {
                 }).block();
     }
 
-    public Product getPrice(final String productName) {
-        Product result;
-        try {
-            result = requestForProduct(productName);
-        } catch (WebClientResponseException e) {
-            log.info("토큰이 만료되어 재발급 요청합니다. {}", e.getMessage());
-
-            accessToken = getToken();
-            result = requestForProduct(productName);
-        }
-
-        validateNull(result);
-        return result;
-    }
-
-    private Product requestForProduct(final String productName) {
-        return vegetableWebClient.get()
+    @Override
+    Product requestForProduct(final String productName) {
+        return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(ProductType.VEGETABLE.productUri())
                         .queryParam("name", productName)
@@ -92,11 +55,5 @@ public class VegetableWebClient {
                 .retrieve()
                 .bodyToMono(Product.class)
                 .block();
-    }
-
-    private <T> void validateNull(T t) {
-        if (t == null) {
-            throw new IllegalStateException("정보를 가져오는 데 실패했습니다.");
-        }
     }
 }

--- a/src/test/java/kimsy/groceryapi/product/application/ProductServiceTest.java
+++ b/src/test/java/kimsy/groceryapi/product/application/ProductServiceTest.java
@@ -11,7 +11,7 @@ import kimsy.groceryapi.product.application.dto.ProductPriceResponse;
 import kimsy.groceryapi.product.application.dto.ProductsResponse;
 import kimsy.groceryapi.product.domain.AccessToken;
 import kimsy.groceryapi.product.domain.FruitWebClient;
-import kimsy.groceryapi.product.domain.ProductWebClient;
+import kimsy.groceryapi.product.domain.ProductWebClientAdapter;
 import kimsy.groceryapi.product.domain.VegetableWebClient;
 import kimsy.groceryapi.product.presentation.dto.ProductPriceRequest;
 import kimsy.groceryapi.product.presentation.dto.ProductsSearchRequest;
@@ -51,11 +51,11 @@ class ProductServiceTest {
     void setUp() {
         final String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
 
-        ProductWebClient productWebClient = new ProductWebClient(
+        ProductWebClientAdapter productWebClientAdapter = new ProductWebClientAdapter(
                 new FruitWebClient(baseUrl, new AccessToken("token")),
                 new VegetableWebClient(baseUrl, new AccessToken("token")));
 
-        productService = new ProductService(productWebClient);
+        productService = new ProductService(productWebClientAdapter);
     }
 
     @DisplayName("품목에 대한 전체 상품 목록이 들어있는 ProductsResponse를 반환한다.")

--- a/src/test/java/kimsy/groceryapi/product/domain/ProductWebClientAdapterTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/ProductWebClientAdapterTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
-class ProductWebClientTest {
+class ProductWebClientAdapterTest {
     private static MockWebServer mockWebServer;
 
     @BeforeAll
@@ -34,13 +34,13 @@ class ProductWebClientTest {
     }
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private ProductWebClient productWebClient;
+    private ProductWebClientAdapter productWebClientAdapter;
 
     @BeforeEach
     void setUp() {
         final String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
 
-        productWebClient = new ProductWebClient(
+        productWebClientAdapter = new ProductWebClientAdapter(
                 new FruitWebClient(baseUrl, new AccessToken("token")),
                 new VegetableWebClient(baseUrl, new AccessToken("token")));
     }
@@ -58,7 +58,7 @@ class ProductWebClientTest {
                     .setBody(objectMapper.writeValueAsString(expect))
                     .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
 
-            final List<String> actual = productWebClient.getProducts(
+            final List<String> actual = productWebClientAdapter.getProducts(
                     ProductType.FRUIT.productTypeName()).values();
 
 
@@ -74,7 +74,7 @@ class ProductWebClientTest {
                     .setBody(objectMapper.writeValueAsString(expect))
                     .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
 
-            final List<String> actual = productWebClient.getProducts(
+            final List<String> actual = productWebClientAdapter.getProducts(
                     ProductType.VEGETABLE.productTypeName()).values();
 
 
@@ -86,7 +86,7 @@ class ProductWebClientTest {
         @Test
         void failCase() {
             final String notSupportedProductType = "고기";
-            assertThatThrownBy(() -> productWebClient.getProducts(notSupportedProductType))
+            assertThatThrownBy(() -> productWebClientAdapter.getProducts(notSupportedProductType))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("서비스를 지원하지 않는 품목입니다.");
         }
@@ -107,7 +107,7 @@ class ProductWebClientTest {
                     .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
 
             final String productType = "fruit";
-            final Product product = productWebClient.getProduct(productType, productName);
+            final Product product = productWebClientAdapter.getProduct(productType, productName);
             assertThat(product.name()).isEqualTo(productName);
             assertThat(product.price()).isEqualTo(productPrice);
         }
@@ -124,7 +124,7 @@ class ProductWebClientTest {
                     .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
 
             final String productType = "vegetable";
-            final Product product = productWebClient.getProduct(productType, productName);
+            final Product product = productWebClientAdapter.getProduct(productType, productName);
             assertThat(product.name()).isEqualTo(productName);
             assertThat(product.price()).isEqualTo(productPrice);
         }
@@ -134,7 +134,7 @@ class ProductWebClientTest {
         void failCase() {
             final String notSupportedType = "고기";
             final String notSupportedName = "한우";
-            assertThatThrownBy(() -> productWebClient.getProduct(notSupportedType, notSupportedName))
+            assertThatThrownBy(() -> productWebClientAdapter.getProduct(notSupportedType, notSupportedName))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("서비스를 지원하지 않는 품목입니다.");
         }


### PR DESCRIPTION
## 요약
중복된 로직을 해결하기 위한 템플릿 메소드 패턴 적용

## 작업 내용 
- `FruitWebClient` 및 `VegetableWebClient`의 대부분의 로직이 중복됨 
    - 둘은 다른 API 서버이나, 비즈니스 로직 상에서는 같은 역할을 하는 객체들이라고 판단되어 `GroceryWebClient`라는 추상 클래스로 묶음 
    - 서로 다르게 작동하는 로직들만 추상 메서드로 빼내어 템플릿화 수행 
- `ProductWebClient` -> `ProductWebClientAdapter`로 이름 변경
    - 서비스 계층에서 보낸 요청에 따라 알맞은 `WebClient`에 전달하므로 `Adapter`가 어울린다고 판단 
    - 그럼에도 어울리지 않는 이름일 수 있으니 지속적인 고민 필요 

