### PR TITLE
refactor: GroceryWebClientMapper의 webClient 탐색 로직 리팩토링

### DIFF
--- a/src/main/java/kimsy/groceryapi/config/GroceryWebClientConfig.java
+++ b/src/main/java/kimsy/groceryapi/config/GroceryWebClientConfig.java
@@ -18,10 +18,10 @@ public class GroceryWebClientConfig {
 
     @Bean
     public GroceryWebClientMapper groceryWebClientMap() {
-        final Map<String, GroceryWebClient> map = Map.of(
-                ProductType.FRUIT.productTypeName(), fruitWebClient,
-                ProductType.VEGETABLE.productTypeName(), vegetableWebClient);
+        final Map<ProductType, GroceryWebClient> webClients = Map.of(
+                ProductType.FRUIT, fruitWebClient,
+                ProductType.VEGETABLE, vegetableWebClient);
 
-        return new GroceryWebClientMapper(map);
+        return new GroceryWebClientMapper(webClients);
     }
 }

--- a/src/main/java/kimsy/groceryapi/product/domain/GroceryWebClientMapper.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/GroceryWebClientMapper.java
@@ -5,9 +5,9 @@ import kimsy.groceryapi.product.domain.web_client.GroceryWebClient;
 import org.springframework.util.StringUtils;
 
 public class GroceryWebClientMapper {
-    private final Map<String, GroceryWebClient> webClients;
+    private final Map<ProductType, GroceryWebClient> webClients;
 
-    public GroceryWebClientMapper(final Map<String, GroceryWebClient> webClients) {
+    public GroceryWebClientMapper(final Map<ProductType, GroceryWebClient> webClients) {
         this.webClients = webClients;
     }
 
@@ -16,18 +16,14 @@ public class GroceryWebClientMapper {
                 .getProducts();
     }
 
-    private GroceryWebClient findHandlerBy(final String productType) {
-        return webClients.keySet().stream()
-                .filter(key -> key.equals(productType))
-                .map(webClients::get)
-                .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("서비스를 지원하지 않는 품목입니다."));
-    }
-
     public Product getProduct(final String productType, final String productName) {
         validate(productName);
         return findHandlerBy(productType)
                 .getProduct(productName);
+    }
+
+    private GroceryWebClient findHandlerBy(final String productType) {
+        return webClients.get(ProductType.of(productType));
     }
 
     private void validate(final String productName) {

--- a/src/main/java/kimsy/groceryapi/product/domain/ProductType.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/ProductType.java
@@ -14,7 +14,7 @@ public enum ProductType {
                     productType -> productType));
 
     public static ProductType of(String productTypeName) {
-        if (!NAME_TYPE_MAP.containsKey(productTypeName)) {
+        if (productTypeName == null || !NAME_TYPE_MAP.containsKey(productTypeName)) {
             throw new IllegalArgumentException("서비스를 지원하지 않는 품목입니다.");
         }
 

--- a/src/main/java/kimsy/groceryapi/product/domain/ProductType.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/ProductType.java
@@ -1,15 +1,24 @@
 package kimsy.groceryapi.product.domain;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public enum ProductType {
     FRUIT("fruit", "/token", "/product", "name"),
     VEGETABLE("vegetable", "/token", "/item", "name");
 
-    public static boolean isFruit(final String productType) {
-        return FRUIT.productTypeName.equals(productType);
-    }
+    private static final Map<String, ProductType> NAME_TYPE_MAP = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(
+                    productType -> productType.productTypeName,
+                    productType -> productType));
 
-    public static boolean isVegetable(final String productType) {
-        return VEGETABLE.productTypeName.equals(productType);
+    public static ProductType of(String productTypeName) {
+        if (!NAME_TYPE_MAP.containsKey(productTypeName)) {
+            throw new IllegalArgumentException("서비스를 지원하지 않는 품목입니다.");
+        }
+
+        return NAME_TYPE_MAP.get(productTypeName);
     }
 
     private final String productTypeName;

--- a/src/test/java/kimsy/groceryapi/product/application/ProductServiceTest.java
+++ b/src/test/java/kimsy/groceryapi/product/application/ProductServiceTest.java
@@ -38,8 +38,8 @@ class ProductServiceTest extends MockWebServerTest {
         final VegetableWebClient vegetableWebClient = new VegetableWebClient(baseUrl, token);
 
         GroceryWebClientMapper groceryWebClientMapper = new GroceryWebClientMapper(Map.of(
-                        ProductType.FRUIT.productTypeName(), fruitWebClient,
-                        ProductType.VEGETABLE.productTypeName(), vegetableWebClient));
+                        ProductType.FRUIT, fruitWebClient,
+                        ProductType.VEGETABLE, vegetableWebClient));
 
         productService = new ProductService(groceryWebClientMapper);
     }

--- a/src/test/java/kimsy/groceryapi/product/domain/GroceryWebClientMapperTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/GroceryWebClientMapperTest.java
@@ -122,7 +122,7 @@ class GroceryWebClientMapperTest extends MockWebServerTest {
 
         @DisplayName("지원되지 않는 품목이 전달된 경우 예외를 발생시킨다.")
         @Test
-        void failCase() {
+        void failCaseCausedByNotSupportedType() {
             final String notSupportedType = "meat";
             final String notSupportedName = "한우";
             assertThatThrownBy(() -> groceryWebClientMapper.getProduct(notSupportedType, notSupportedName))
@@ -130,9 +130,10 @@ class GroceryWebClientMapperTest extends MockWebServerTest {
                     .hasMessageContaining("서비스를 지원하지 않는 품목입니다.");
         }
 
-        @ParameterizedTest(name = "품목명에 빈 값이나 null이 전달될 경우 예외를 발생시킨다. 입력={0}")
+        @DisplayName("품목명에 빈 값이나 null이 전달될 경우 예외를 발생시킨다.")
+        @ParameterizedTest(name = "입력={0}")
         @NullAndEmptySource
-        void failCase2(String nullOrEmpty) {
+        void failCaseCausedByNullOrEmpty(String nullOrEmpty) {
             final String supportedType = ProductType.FRUIT.productTypeName();
             assertThatThrownBy(() -> groceryWebClientMapper.getProduct(supportedType, nullOrEmpty))
                     .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/kimsy/groceryapi/product/domain/GroceryWebClientMapperTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/GroceryWebClientMapperTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -38,7 +40,6 @@ class GroceryWebClientMapperTest extends MockWebServerTest {
     @DisplayName("청과물 분류 별 전체 품목을 조회하는 기능")
     @Nested
     class GetProducts {
-
         @DisplayName("ProductType으로 fruit이 전달된 경우 과일 목록을 반환한다.")
         @Test
         void fruitToProductNames() throws JsonProcessingException {
@@ -122,11 +123,20 @@ class GroceryWebClientMapperTest extends MockWebServerTest {
         @DisplayName("지원되지 않는 품목이 전달된 경우 예외를 발생시킨다.")
         @Test
         void failCase() {
-            final String notSupportedType = "고기";
+            final String notSupportedType = "meat";
             final String notSupportedName = "한우";
             assertThatThrownBy(() -> groceryWebClientMapper.getProduct(notSupportedType, notSupportedName))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("서비스를 지원하지 않는 품목입니다.");
+        }
+
+        @ParameterizedTest(name = "품목명에 빈 값이나 null이 전달될 경우 예외를 발생시킨다. 입력={0}")
+        @NullAndEmptySource
+        void failCase2(String nullOrEmpty) {
+            final String supportedType = ProductType.FRUIT.productTypeName();
+            assertThatThrownBy(() -> groceryWebClientMapper.getProduct(supportedType, nullOrEmpty))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("품목명을 입력해 주세요.");
         }
     }
 }

--- a/src/test/java/kimsy/groceryapi/product/domain/GroceryWebClientMapperTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/GroceryWebClientMapperTest.java
@@ -30,8 +30,8 @@ class GroceryWebClientMapperTest extends MockWebServerTest {
         final VegetableWebClient vegetableWebClient = new VegetableWebClient(baseUrl, token);
 
         groceryWebClientMapper = new GroceryWebClientMapper(Map.of(
-                ProductType.FRUIT.productTypeName(), fruitWebClient,
-                ProductType.VEGETABLE.productTypeName(), vegetableWebClient));
+                ProductType.FRUIT, fruitWebClient,
+                ProductType.VEGETABLE, vegetableWebClient));
     }
 
 

--- a/src/test/java/kimsy/groceryapi/product/domain/ProductTypeTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/ProductTypeTest.java
@@ -1,0 +1,45 @@
+package kimsy.groceryapi.product.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ProductTypeTest {
+    @DisplayName("지원되는 품목이 입력될 경우 그에 맞는 ProductType을 반환한다.")
+    @ParameterizedTest(name = "입력={0}, {1}")
+    @MethodSource("successCaseArguments")
+    void success(String productTypeName, ProductType productType) {
+        assertThat(ProductType.of(productTypeName)).isEqualTo(productType);
+    }
+
+    static Stream<Arguments> successCaseArguments() {
+        return Stream.of(
+                Arguments.of("fruit", ProductType.FRUIT),
+                Arguments.of("vegetable", ProductType.VEGETABLE));
+    }
+
+    @DisplayName("지원되지 않는 품목이 입력될 경우 예외를 발생시킨다.")
+    @ParameterizedTest(name = "입력={0}")
+    @ValueSource(strings = {"meat", "fruitBox", "vegetableBall"})
+    void failByNotSupportedProductType(String productTypeName) {
+        assertThatThrownBy(() -> ProductType.of(productTypeName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("서비스를 지원하지 않는 품목입니다.");
+    }
+
+    @DisplayName("품목이 빈값이거나 null일 경우 예외를 발생시킨다.")
+    @ParameterizedTest(name = "입력={0}")
+    @NullAndEmptySource
+    void failByNullOrEmpty(String productTypeName) {
+        assertThatThrownBy(() -> ProductType.of(productTypeName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("서비스를 지원하지 않는 품목입니다.");
+    }
+}


### PR DESCRIPTION
## 요약
GroceryWebClientMapper의 webClient 탐색 로직 리팩토링

## 작업 내용 
- as-is
    - keySet을 순회하면서 맞는 키를 찾아 값을 리턴해주는 방식  
- to-be
    - Map에서 key로 직접 값을 꺼내는 방식 
    - key의 타입을 String -> ProductType으로 변경 
    - ProductType 내부에서 해당 품목에 대한 서비스를 지원하는지 판단하고, 지원하지 않을 경우 예외를 발생시킴 

### 테스트
- `GroceryWebClientMapper` 테스트 케이스 추가 (null, empty)
- `ProductType`에 대한 테스트 코드 작성 

