### PR TITLE
test: GroceryWebClient 관련 테스트 코드 작성

### DIFF
--- a/src/main/java/kimsy/groceryapi/product/domain/GroceryWebClientMapper.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/GroceryWebClientMapper.java
@@ -2,7 +2,6 @@ package kimsy.groceryapi.product.domain;
 
 import java.util.Map;
 import kimsy.groceryapi.product.domain.web_client.GroceryWebClient;
-import org.springframework.util.StringUtils;
 
 public class GroceryWebClientMapper {
     private final Map<ProductType, GroceryWebClient> webClients;
@@ -17,18 +16,11 @@ public class GroceryWebClientMapper {
     }
 
     public Product getProduct(final String productType, final String productName) {
-        validate(productName);
         return findHandlerBy(productType)
                 .getProduct(productName);
     }
 
     private GroceryWebClient findHandlerBy(final String productType) {
         return webClients.get(ProductType.of(productType));
-    }
-
-    private void validate(final String productName) {
-        if (!StringUtils.hasText(productName)) {
-            throw new IllegalArgumentException("품목명을 입력해 주세요.");
-        }
     }
 }

--- a/src/main/java/kimsy/groceryapi/product/domain/web_client/FruitWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/web_client/FruitWebClient.java
@@ -40,6 +40,8 @@ public class FruitWebClient extends GroceryWebClient {
 
     @Override
     Product requestForProduct(final String productName) {
+        validateNullOrEmpty(productName);
+
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(ProductType.FRUIT.productUri())

--- a/src/main/java/kimsy/groceryapi/product/domain/web_client/GroceryWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/web_client/GroceryWebClient.java
@@ -5,6 +5,7 @@ import kimsy.groceryapi.product.domain.AccessToken;
 import kimsy.groceryapi.product.domain.Product;
 import kimsy.groceryapi.product.domain.Products;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
@@ -61,6 +62,12 @@ public abstract class GroceryWebClient {
 
         validateNull(result);
         return result;
+    }
+
+    protected void validateNullOrEmpty(final String productName) {
+        if (!StringUtils.hasText(productName)) {
+            throw new IllegalArgumentException("품목명을 입력해 주세요.");
+        }
     }
 
     abstract Product requestForProduct(String productName);

--- a/src/main/java/kimsy/groceryapi/product/domain/web_client/VegetableWebClient.java
+++ b/src/main/java/kimsy/groceryapi/product/domain/web_client/VegetableWebClient.java
@@ -49,6 +49,8 @@ public class VegetableWebClient extends GroceryWebClient {
 
     @Override
     Product requestForProduct(final String productName) {
+        validateNullOrEmpty(productName);
+
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(ProductType.VEGETABLE.productUri())

--- a/src/test/java/kimsy/groceryapi/product/domain/web_client/FruitWebClientTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/web_client/FruitWebClientTest.java
@@ -1,0 +1,73 @@
+package kimsy.groceryapi.product.domain.web_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import kimsy.groceryapi.product.domain.AccessToken;
+import kimsy.groceryapi.product.domain.Product;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@SpringBootTest
+class FruitWebClientTest {
+    @Autowired
+    private MockFruitWebClient mockFruitWebClient;
+
+    @DisplayName("외부 API에 토큰을 요청하고 성공하는 경우 200OK를 반환 받고, AccessToken 타입을 반환한다.")
+    @Test
+    void getToken() {
+        final ResponseEntity<AccessToken> response = mockFruitWebClient.getToken();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(AccessToken.class);
+    }
+
+    @DisplayName("외부 API에 상품 목록 요청을 보내고 성공하는 경우 200OK를 반환 받고, String[] 타입을 반환한다.")
+    @Test
+    void requestForProducts() {
+        final ResponseEntity<String[]> response = mockFruitWebClient.requestForProducts();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(String[].class);
+    }
+
+    @DisplayName("외부 API에 상품 가격 요청을 보내는 경우")
+    @Nested
+    class RequestForProduct {
+        @DisplayName("성공할 경우 200OK를 반환 받고, Product 타입을 반환한다.")
+        @Test
+        void success() {
+            final String productName = "배";
+            final ResponseEntity<Product> response = mockFruitWebClient
+                    .requestForProduct(productName);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isInstanceOf(Product.class);
+        }
+
+        @DisplayName("없는 품목을 요청할 경우 예외를 발생시킨다.")
+        @ParameterizedTest(name = "입력={0}")
+        @ValueSource(strings = {"치커리", "상추", "깻잎"})
+        void failByNotSupportedProductName(String productName) {
+            assertThatThrownBy(() -> mockFruitWebClient.requestForProduct(productName))
+                    .isInstanceOf(WebClientResponseException.NotFound.class);
+        }
+
+        @DisplayName("null 혹은 빈 값을 요청할 경우 예외를 발생시킨다.")
+        @ParameterizedTest(name = "입력={0}")
+        @NullAndEmptySource
+        void failByNullOrEmptyProductName(String productName) {
+            assertThatThrownBy(() -> mockFruitWebClient.requestForProduct(productName))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/kimsy/groceryapi/product/domain/web_client/MockFruitWebClient.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/web_client/MockFruitWebClient.java
@@ -1,0 +1,56 @@
+package kimsy.groceryapi.product.domain.web_client;
+
+import kimsy.groceryapi.product.domain.AccessToken;
+import kimsy.groceryapi.product.domain.Product;
+import kimsy.groceryapi.product.domain.ProductType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MockFruitWebClient extends MockGroceryWebClient {
+    @Autowired
+    public MockFruitWebClient(@Value("${api.url.fruit}") String fruitUrl) {
+        super(fruitUrl);
+    }
+
+    public MockFruitWebClient(final String fruitUrl, final AccessToken accessToken) {
+        super(fruitUrl, accessToken);
+    }
+
+    @Override
+    ResponseEntity<String[]> requestForProducts() {
+        return webClient.get()
+                .uri(ProductType.FRUIT.productUri())
+                .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
+                .retrieve()
+                .toEntity(String[].class)
+                .block();
+    }
+
+    @Override
+    ResponseEntity<AccessToken> getToken() {
+        return webClient.get()
+                .uri(ProductType.FRUIT.tokenUri())
+                .retrieve()
+                .toEntity(AccessToken.class)
+                .block();
+    }
+
+    @Override
+    ResponseEntity<Product> requestForProduct(final String productName) {
+        validateNullOrEmpty(productName);
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(ProductType.FRUIT.productUri())
+                        .queryParam(ProductType.FRUIT.priceParamKey(), productName)
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
+                .retrieve()
+                .toEntity(Product.class)
+                .block();
+    }
+}

--- a/src/test/java/kimsy/groceryapi/product/domain/web_client/MockGroceryWebClient.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/web_client/MockGroceryWebClient.java
@@ -1,0 +1,33 @@
+package kimsy.groceryapi.product.domain.web_client;
+
+import kimsy.groceryapi.product.domain.AccessToken;
+import kimsy.groceryapi.product.domain.Product;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+public abstract class MockGroceryWebClient {
+    protected final WebClient webClient;
+    protected AccessToken accessToken;
+
+    public MockGroceryWebClient(final String url) {
+        this.webClient = WebClient.builder().baseUrl(url).build();
+        this.accessToken = getToken().getBody();
+    }
+
+    public MockGroceryWebClient(final String url, final AccessToken accessToken) {
+        this.webClient = WebClient.builder().baseUrl(url).build();
+        this.accessToken = accessToken;
+    }
+
+    abstract ResponseEntity<AccessToken> getToken();
+    abstract ResponseEntity<String[]> requestForProducts();
+    abstract ResponseEntity<Product> requestForProduct(String productName);
+
+    protected void validateNullOrEmpty(final String productName) {
+        if (!StringUtils.hasText(productName)) {
+            throw new IllegalArgumentException("품목명을 입력해 주세요.");
+        }
+    }
+}

--- a/src/test/java/kimsy/groceryapi/product/domain/web_client/MockVegetableWebClient.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/web_client/MockVegetableWebClient.java
@@ -1,0 +1,65 @@
+package kimsy.groceryapi.product.domain.web_client;
+
+import kimsy.groceryapi.product.domain.AccessToken;
+import kimsy.groceryapi.product.domain.Product;
+import kimsy.groceryapi.product.domain.ProductType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class MockVegetableWebClient extends MockGroceryWebClient {
+    @Autowired
+    public MockVegetableWebClient(@Value("${api.url.vegetable}") String vegetableUrl) {
+        super(vegetableUrl);
+    }
+
+    public MockVegetableWebClient(final String vegetableUrl, final AccessToken accessToken) {
+        super(vegetableUrl, accessToken);
+    }
+
+    @Override
+    ResponseEntity<String[]> requestForProducts() {
+        return webClient.get()
+                .uri(ProductType.VEGETABLE.productUri())
+                .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
+                .retrieve()
+                .toEntity(String[].class)
+                .block();
+    }
+
+    @Override
+    ResponseEntity<AccessToken> getToken() {
+        return webClient.get()
+                .uri(ProductType.VEGETABLE.tokenUri())
+                .exchangeToMono(response -> {
+                    final ResponseCookie responseCookie = response.cookies()
+                            .getFirst(HttpHeaders.AUTHORIZATION);
+
+                    if (responseCookie == null) {
+                        throw new IllegalStateException("정보를 가져오는 데 실패했습니다.");
+                    }
+                    return Mono.just(new ResponseEntity<>(
+                            new AccessToken(responseCookie.getValue()), response.statusCode()));
+                }).block();
+    }
+
+    @Override
+    ResponseEntity<Product> requestForProduct(final String productName) {
+        validateNullOrEmpty(productName);
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(ProductType.VEGETABLE.productUri())
+                        .queryParam(ProductType.VEGETABLE.priceParamKey(), productName)
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, accessToken.accessToken())
+                .retrieve()
+                .toEntity(Product.class)
+                .block();
+    }
+}

--- a/src/test/java/kimsy/groceryapi/product/domain/web_client/VegetableWebClientTest.java
+++ b/src/test/java/kimsy/groceryapi/product/domain/web_client/VegetableWebClientTest.java
@@ -1,0 +1,73 @@
+package kimsy.groceryapi.product.domain.web_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import kimsy.groceryapi.product.domain.AccessToken;
+import kimsy.groceryapi.product.domain.Product;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@SpringBootTest
+class VegetableWebClientTest {
+    @Autowired
+    private MockVegetableWebClient mockVegetableWebClient;
+
+    @DisplayName("외부 API에 토큰을 요청하고 성공하는 경우 200OK를 반환 받고, AccessToken 타입을 반환한다.")
+    @Test
+    void getToken() {
+        final ResponseEntity<AccessToken> response = mockVegetableWebClient.getToken();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(AccessToken.class);
+    }
+
+    @DisplayName("외부 API에 상품 목록 요청을 보내고 성공하는 경우 200OK를 반환 받고, String[] 타입을 반환한다.")
+    @Test
+    void requestForProducts() {
+        final ResponseEntity<String[]> response = mockVegetableWebClient.requestForProducts();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(String[].class);
+    }
+
+    @DisplayName("외부 API에 상품 가격 요청을 보내는 경우")
+    @Nested
+    class RequestForProduct {
+        @DisplayName("성공할 경우 200OK를 반환 받고, Product 타입을 반환한다.")
+        @Test
+        void success() {
+            final String productName = "치커리";
+            final ResponseEntity<Product> response = mockVegetableWebClient
+                    .requestForProduct(productName);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isInstanceOf(Product.class);
+        }
+
+        @DisplayName("없는 품목을 요청할 경우 예외를 발생시킨다.")
+        @ParameterizedTest(name = "입력={0}")
+        @ValueSource(strings = {"사과", "배", "바나나"})
+        void failByNotSupportedProductName(String productName) {
+            assertThatThrownBy(() -> mockVegetableWebClient.requestForProduct(productName))
+                    .isInstanceOf(WebClientResponseException.NotFound.class);
+        }
+
+        @DisplayName("null 혹은 빈 값을 요청할 경우 예외를 발생시킨다.")
+        @ParameterizedTest(name = "입력={0}")
+        @NullAndEmptySource
+        void failByNullOrEmptyProductName(String productName) {
+            assertThatThrownBy(() -> mockVegetableWebClient.requestForProduct(productName))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
GroceryWebClient 관련 테스트 코드 작성

## 작업 내용 
- `GroceryWebClient` 관련 로직에 대한 테스트 코드 작성
    -  외부 API에 대한 응답이 잘 내려오는지를 판단하기 위해 작성 
    - `ResponseEntity`로 받아 `statusCode`를 받고, 핵심 로직만 테스트 하기 위해 `GroceryWebClient`와 이하 자식 객체들을 전부 Mocking한 후 테스트 수행


- Test코드 작성 중, null과 empty 값에 대한 방어를 하지 않았음이 발견되어, `GroceryWebClient` 내에 `productName`에 대해 null이나 빈 값이 아닌지를 validation하는 메서드 작성 
